### PR TITLE
FollowPath changes

### DIFF
--- a/pokemongo_bot/cell_workers/follow_path.py
+++ b/pokemongo_bot/cell_workers/follow_path.py
@@ -27,25 +27,29 @@ class FollowPath(BaseTask):
 
     def initialize(self):
         self._process_config()
-        self.points = self.load_path()
-        self.status = STATUS_MOVING
-        self.waiting_end_time = 0
-        self.distance_unit = self.bot.config.distance_unit
-        self.append_unit = False
+        if self.enable:
+            self.points = self.load_path()
+            self.status = STATUS_MOVING
+            self.waiting_end_time = 0
+            self.distance_unit = self.bot.config.distance_unit
+            self.append_unit = False
 
-        if self.path_start_mode == 'closest':
-            self.ptr = self.find_closest_point_idx(self.points)
+            if self.path_start_mode == 'closest':
+                self.ptr = self.find_closest_point_idx(self.points)
 
-        else:
-            self.ptr = 0
+            else:
+                self.ptr = 0
             
-        if self.disable_location_output:
-            self.emit_event(
-                'followpath_output_disabled',
-                formatted="Bot in follow path mode, position update disabled. You will not be inform of path taken by bot."
-            )
+            if self.disable_location_output:
+                self.emit_event(
+                    'followpath_output_disabled',
+                    formatted="Bot in follow path mode, position update disabled. You will not be inform of path taken by bot."
+                )
+        else:
+            self.status = STATUS_FINISHED
 
     def _process_config(self):
+        self.enable = self.config.get("enable", True)
         self.path_file = self.config.get("path_file", None)
         self.path_mode = self.config.get("path_mode", "linear")
         self.path_start_mode = self.config.get("path_start_mode", "first")

--- a/pokemongo_bot/cell_workers/spin_fort.py
+++ b/pokemongo_bot/cell_workers/spin_fort.py
@@ -108,6 +108,7 @@ class SpinFort(BaseTask):
                             'items': awards
                         }
                     )
+                    #time.sleep(10)
                 else:
                     self.emit_event(
                         'pokestop_empty',


### PR DESCRIPTION
Currently FollowPath do not have a enable setting in Config. This will allow user to enable or disable follow Path instead of deleting the whole setting from config.

Planned features for FollowPath:
1. Online source for path json
2. Search path json base on nest
3. Disable followpath when nest has expired
4. Change to sleep_schedule & followpath, so that "wake_up_at_location" can also work for path